### PR TITLE
Remove duplicate GitPython requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ fairscale>=0.4.12
 filelock>=3.8.0
 Flask>=3.0.2
 fvcore>=0.1.5.post20220512
-GitPython>=3.1.28
 GitPython>=3.1.42
 h5py>=3.10.0
 hydra-core>=1.3.2


### PR DESCRIPTION
Since one requirement is for >= 3.1.42 and the other is for >= 3.1.28 you should just need a version greater than 3.1.42 to satisfy both conditions.