### PR TITLE
Remove redundant conditional from test file

### DIFF
--- a/test.py
+++ b/test.py
@@ -4,35 +4,48 @@ import argparse
 from leafmachine2.machine.machine import machine
 from leafmachine2.machine.general_utils import load_config_file_testing
 
-def test_LM2(redownload=False):
-    is_test = True
 
-    # Set LeafMachine2 dir 
+def test_LM2(redownload=False):
+    # Set LeafMachine2 dir
     dir_home = os.path.dirname(__file__)
 
     # If there's an error in the code that causes the ML model placement, the easiest way to fix it is to
     # delete everything in /bin and start over
     if redownload:
-        bin_dir = os.path.join(dir_home, 'bin')
+        bin_dir = os.path.join(dir_home, "bin")
         if os.path.exists(bin_dir):
             shutil.rmtree(bin_dir)
             print(f"Deleted contents of {bin_dir}")
         else:
             print(f"{bin_dir} does not exist. No contents to delete.")
 
-    if is_test:
-        cfg_file_path = os.path.join(dir_home, 'demo', 'demo.yaml')
+    cfg_file_path = os.path.join(dir_home, "demo", "demo.yaml")
 
-        cfg_testing = load_config_file_testing(dir_home, cfg_file_path)
-        cfg_testing['leafmachine']['project']['dir_images_local'] = os.path.join(dir_home, cfg_testing['leafmachine']['project']['dir_images_local'][0], cfg_testing['leafmachine']['project']['dir_images_local'][1])
-        cfg_testing['leafmachine']['project']['dir_output'] = os.path.join(dir_home, cfg_testing['leafmachine']['project']['dir_output'][0], cfg_testing['leafmachine']['project']['dir_output'][1])
+    cfg_testing = load_config_file_testing(dir_home, cfg_file_path)
+    cfg_testing["leafmachine"]["project"]["dir_images_local"] = os.path.join(
+        dir_home,
+        cfg_testing["leafmachine"]["project"]["dir_images_local"][0],
+        cfg_testing["leafmachine"]["project"]["dir_images_local"][1],
+    )
+    cfg_testing["leafmachine"]["project"]["dir_output"] = os.path.join(
+        dir_home,
+        cfg_testing["leafmachine"]["project"]["dir_output"][0],
+        cfg_testing["leafmachine"]["project"]["dir_output"][1],
+    )
 
-        machine(cfg_file_path, dir_home, cfg_testing)
+    machine(cfg_file_path, dir_home, cfg_testing)
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Test LeafMachine2 with optional redownload.")
-    parser.add_argument('--redownload', action='store_true', help="Delete the contents of the /bin folder before running.")
-    
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Test LeafMachine2 with optional redownload."
+    )
+    parser.add_argument(
+        "--redownload",
+        action="store_true",
+        help="Delete the contents of the /bin folder before running.",
+    )
+
     args = parser.parse_args()
-    
+
     test_LM2(redownload=args.redownload)


### PR DESCRIPTION
As `is_test = True` was defined by the function itself, there would never be a case in which the condition is not met, thus making the if statement redundant. This patch removes the if statement for that condition.