### PR TITLE
Fixes pip install error due to inline comment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,9 @@ pandas>=1.5.0
 pandastable>=0.13.1
 parse>=1.20.1
 Pillow>=10.2.0
-protobuf>=3.20.0#"protobuf>=3.21,<5.0.0"#protobuf>=3.20.0
+protobuf>=3.20.0
+#"protobuf>=3.21,<5.0.0"
+#protobuf>=3.20.0
 psutil>=5.9.4
 py_cpuinfo>=9.0.0
 pyexiv2>=2.8.1


### PR DESCRIPTION
Fixes error received when executing `pip -r install requirements.txt`  probably due to the inline comment after the package declaration.